### PR TITLE
chore(lint): clean up moneyx + decimalx submodule lint warnings

### DIFF
--- a/decimalx/decimal.go
+++ b/decimalx/decimal.go
@@ -18,18 +18,31 @@ const (
 	NanoSize = 1_000_000_000
 	// MaxNanosValue is the maximum value for nanos (10^9 - 1).
 	MaxNanosValue = 999999999
+	// ctxPrecision is the precision (in significant digits) used by the
+	// shared apd context.
+	ctxPrecision = 38
+	// ctxMaxExponent / ctxMinExponent bound the shared context.
+	ctxMaxExponent = 5000
+	ctxMinExponent = -5000
+	// basisPointsPerOne is the divisor used to translate basis points
+	// (1/100 of a percent) into a decimal fraction.
+	basisPointsPerOne = 10000
 )
 
 // ctx is the shared arithmetic context: 38 digits, half-up rounding.
+//
+//nolint:gochecknoglobals // single shared apd.Context is intentional.
 var ctx = &apd.Context{
-	Precision:   38,
+	Precision:   ctxPrecision,
 	Rounding:    apd.RoundHalfUp,
-	MaxExponent: 5000,
-	MinExponent: -5000,
+	MaxExponent: ctxMaxExponent,
+	MinExponent: ctxMinExponent,
 	Traps:       apd.DefaultTraps,
 }
 
 // Decimal wraps *apd.Decimal for precise decimal calculations.
+//
+//nolint:recvcheck // Scan/UnmarshalJSON intentionally use pointer receivers.
 type Decimal struct {
 	d *apd.Decimal
 }
@@ -84,7 +97,7 @@ func Zero() Decimal {
 // For example, 1500 bp becomes 0.15.
 func NewFromBasisPoints(bp int64) Decimal {
 	result := new(apd.Decimal)
-	_, _ = ctx.Quo(result, apd.New(bp, 0), apd.New(10000, 0))
+	_, _ = ctx.Quo(result, apd.New(bp, 0), apd.New(basisPointsPerOne, 0))
 	return Decimal{d: result}
 }
 
@@ -265,7 +278,7 @@ func (v Decimal) Int64() int64 {
 // ApplyBasisPoints computes amount * bp / 10000.
 func ApplyBasisPoints(amount Decimal, bp int64) Decimal {
 	bpDec := apd.New(bp, 0)
-	divisor := apd.New(10000, 0)
+	divisor := apd.New(basisPointsPerOne, 0)
 
 	tmp := new(apd.Decimal)
 	_, _ = ctx.Mul(tmp, amount.inner(), bpDec)

--- a/decimalx/decimal_test.go
+++ b/decimalx/decimal_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage // tests exercise unexported helpers
 package decimalx
 
 import (
@@ -241,8 +242,8 @@ func TestJSONRoundTrip(t *testing.T) {
 	}
 
 	var got Decimal
-	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatal(err)
+	if uerr := json.Unmarshal(data, &got); uerr != nil {
+		t.Fatal(uerr)
 	}
 	if !got.Equal(orig) {
 		t.Errorf("unmarshal round-trip: got %s, want %s", got, orig)

--- a/moneyx/currency.go
+++ b/moneyx/currency.go
@@ -1,4 +1,4 @@
-// Package money — ISO 4217 currency precision lookup and strict
+// Package moneyx — ISO 4217 currency precision lookup and strict
 // conversion helpers. The conversions in moneyx.go take an explicit
 // `decimals` parameter; in many callers the decimals are determined
 // solely by the currency code, and a strict check that the wire money
@@ -13,10 +13,24 @@ import (
 	commonv1 "buf.build/gen/go/antinvestor/common/protocolbuffers/go/common/v1"
 )
 
+// Default ISO 4217 fractional digit counts.
+const (
+	// DecimalsZero is used by codes like JPY, KRW, UGX where the major and
+	// minor unit are identical.
+	DecimalsZero int32 = 0
+	// DecimalsTwo is the default precision and covers the majority of ISO
+	// 4217 codes.
+	DecimalsTwo int32 = 2
+	// DecimalsThree is used by Gulf and Tunisian codes (BHD, IQD, etc.).
+	DecimalsThree int32 = 3
+)
+
 // ─── ISO 4217 precision lookup ──────────────────────────────────────
 
 // zeroDecimal is the set of ISO 4217 codes whose minor unit equals the
 // major unit (no fractional digits).
+//
+//nolint:gochecknoglobals // ISO 4217 lookup table — effectively const.
 var zeroDecimal = map[string]struct{}{
 	"BIF": {}, "CLP": {}, "DJF": {}, "GNF": {}, "ISK": {}, "JPY": {},
 	"KMF": {}, "KRW": {}, "PYG": {}, "RWF": {}, "UGX": {}, "UYI": {},
@@ -24,6 +38,8 @@ var zeroDecimal = map[string]struct{}{
 }
 
 // threeDecimal is the set of ISO 4217 codes with three fractional digits.
+//
+//nolint:gochecknoglobals // ISO 4217 lookup table — effectively const.
 var threeDecimal = map[string]struct{}{
 	"BHD": {}, "IQD": {}, "JOD": {}, "KWD": {}, "LYD": {}, "OMR": {}, "TND": {},
 }
@@ -35,12 +51,12 @@ var threeDecimal = map[string]struct{}{
 func Decimals(currencyCode string) int32 {
 	c := strings.ToUpper(strings.TrimSpace(currencyCode))
 	if _, ok := zeroDecimal[c]; ok {
-		return 0
+		return DecimalsZero
 	}
 	if _, ok := threeDecimal[c]; ok {
-		return 3
+		return DecimalsThree
 	}
-	return 2
+	return DecimalsTwo
 }
 
 // ─── Strict converters ──────────────────────────────────────────────

--- a/moneyx/currency_test.go
+++ b/moneyx/currency_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage // tests exercise unexported helpers
 package moneyx
 
 import (

--- a/moneyx/moneyx_test.go
+++ b/moneyx/moneyx_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage // tests exercise unexported helpers
 package moneyx
 
 import (
@@ -147,11 +148,11 @@ func TestSmallestUnitRoundTrip_Cents(t *testing.T) {
 		t.Errorf("ToSmallestUnit(10.50 USD, 2) = %d, want 1050", cents)
 	}
 	back := FromSmallestUnit("USD", cents, 2)
-	if back.Units != 10 || back.Nanos != 500000000 {
+	if back.GetUnits() != 10 || back.GetNanos() != 500000000 {
 		t.Errorf(
 			"FromSmallestUnit(1050, 2) = {%d, %d}, want {10, 500000000}",
-			back.Units,
-			back.Nanos,
+			back.GetUnits(),
+			back.GetNanos(),
 		)
 	}
 }
@@ -164,11 +165,11 @@ func TestSmallestUnitRoundTrip_Satoshi(t *testing.T) {
 		t.Errorf("ToSmallestUnit(1.5 BTC, 8) = %d, want 150000000", sats)
 	}
 	back := FromSmallestUnit("BTC", sats, 8)
-	if back.Units != 1 || back.Nanos != 500000000 {
+	if back.GetUnits() != 1 || back.GetNanos() != 500000000 {
 		t.Errorf(
 			"FromSmallestUnit(150000000, 8) = {%d, %d}, want {1, 500000000}",
-			back.Units,
-			back.Nanos,
+			back.GetUnits(),
+			back.GetNanos(),
 		)
 	}
 }
@@ -184,19 +185,19 @@ func TestSmallestUnitDecimal_Wei(t *testing.T) {
 
 	// Round-trip back
 	back := FromSmallestUnitDecimal("ETH", wei, 18)
-	if back.Units != 1 || back.Nanos != 500000000 {
+	if back.GetUnits() != 1 || back.GetNanos() != 500000000 {
 		t.Errorf(
 			"FromSmallestUnitDecimal round-trip: {%d, %d}, want {1, 500000000}",
-			back.Units,
-			back.Nanos,
+			back.GetUnits(),
+			back.GetNanos(),
 		)
 	}
 }
 
 func TestFromInt64_Alias(t *testing.T) {
 	m := FromInt64("KES", 15050, 2)
-	if m.Units != 150 || m.Nanos != 500000000 {
-		t.Errorf("FromInt64(KES, 15050, 2) = {%d, %d}, want {150, 500000000}", m.Units, m.Nanos)
+	if m.GetUnits() != 150 || m.GetNanos() != 500000000 {
+		t.Errorf("FromInt64(KES, 15050, 2) = {%d, %d}, want {150, 500000000}", m.GetUnits(), m.GetNanos())
 	}
 }
 


### PR DESCRIPTION
## Summary

Standalone \`golangci-lint\` runs on the \`moneyx/\` and \`decimalx/\` submodules surfaced a small batch of warnings that the root-only CI doesn't see. None are behavioral; this brings each submodule to zero findings under util's shared config.

## moneyx

- Name \`DecimalsZero\` / \`DecimalsTwo\` / \`DecimalsThree\` constants in place of bare \`2\`/\`3\` return literals (mnd).
- Annotate the ISO 4217 lookup tables (\`zeroDecimal\`, \`threeDecimal\`) as intentional package-level state (gochecknoglobals).
- Use \`GetUnits()\`/\`GetNanos()\` getters in tests (protogetter).
- Rename misleading \`// Package money — …\` comment to \`// Package moneyx — …\` (revive).
- Add \`//nolint:testpackage\` on test files — they exercise unexported helpers.

## decimalx

- Name \`ctxPrecision\` / \`ctxMaxExponent\` / \`ctxMinExponent\` / \`basisPointsPerOne\` (mnd).
- Annotate the shared \`apd.Context\` as intentional (gochecknoglobals).
- Rename a shadowed \`err\` in \`TestJSONRoundTrip\`.
- Mark the \`Decimal\` type's mixed receiver style as intentional (recvcheck — \`Scan\`/\`UnmarshalJSON\` need pointer receivers).
- Add \`//nolint:testpackage\` on the test file.

## Test plan

- [x] \`go test -race ./...\` passes in both submodules.
- [x] \`golangci-lint run ./...\` reports 0 issues in both submodules.