### PR TITLE
fix(log): MultiHandler.Handle must respect each child's Enabled level

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -258,7 +258,14 @@ func (m *MultiHandler) Enabled(ctx context.Context, level slog.Level) bool {
 
 func (m *MultiHandler) Handle(ctx context.Context, r slog.Record) error {
 	for _, h := range m.handlers {
-		if err := h.Handle(ctx, r); err != nil {
+		// Enabled is re-checked per child: MultiHandler.Enabled reports true
+		// if ANY child accepts the level, so a permissive child (e.g. an
+		// OTel exporter handler) must not force records onto children whose
+		// level filters them out.
+		if !h.Enabled(ctx, r.Level) {
+			continue
+		}
+		if err := h.Handle(ctx, r.Clone()); err != nil {
 			return err
 		}
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -135,6 +135,7 @@ func TestMultiHandlerVerification(t *testing.T) {
 	t.Run("HandlerExclusiveMode", testHandlerExclusiveMode)
 	t.Run("DefaultMultiHandlerBehavior", testDefaultMultiHandlerBehavior)
 	t.Run("MultipleHandlersViaMultipleLoggers", testMultipleHandlersViaMultipleLoggers)
+	t.Run("ChildLevelRespectedInFanOut", testChildLevelRespectedInFanOut)
 	t.Run("JSONFormatOutput", testJSONFormatOutput)
 	t.Run("HandlerWrapper", testHandlerWrapper)
 }
@@ -274,6 +275,40 @@ func testHandlerWrapper(t *testing.T) {
 	output := buf.String()
 	if !strings.Contains(output, `"injected":"trace123"`) {
 		t.Errorf("Handler wrapper did not inject attribute, got: %s", output)
+	}
+}
+
+// A permissive child handler (e.g. an OTel exporter that accepts every
+// level) must not cause records to reach children whose own level filters
+// them out. Regression: Handle fanned out without re-checking each child's
+// Enabled, so LOG_LEVEL=info still printed DEBUG lines to stdout whenever
+// a telemetry handler was attached.
+func testChildLevelRespectedInFanOut(t *testing.T) {
+	ctx := t.Context()
+	var infoBuf, permissiveBuf bytes.Buffer
+	permissiveHandler := slog.NewJSONHandler(&permissiveBuf, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+	// The standard handler is built at the configured level (info, capturing
+	// to infoBuf); the extra handler is permissive (debug). This mirrors
+	// frame attaching an OTel exporter handler next to the stdout handler.
+	logger := util.NewLogger(ctx,
+		util.WithLogLevel(slog.LevelInfo),
+		util.WithLogFormat("json"),
+		util.WithLogOutput(&infoBuf),
+		util.WithLogHandler(permissiveHandler))
+	defer logger.Release()
+
+	logger.Debug("debug message")
+	logger.Info("info message")
+
+	if strings.Contains(infoBuf.String(), "debug message") {
+		t.Errorf("info-level handler received a debug record via fan-out: %s", infoBuf.String())
+	}
+	if !strings.Contains(permissiveBuf.String(), "debug message") {
+		t.Error("debug-level handler should still receive debug records")
+	}
+	if !strings.Contains(infoBuf.String(), "info message") {
+		t.Error("info-level handler should receive info records")
 	}
 }
 


### PR DESCRIPTION
## Problem

`MultiHandler.Enabled` reports true if **any** child accepts the level, and `Handle` fanned records out to **every** child without re-checking that child's own `Enabled`. A permissive child handler (e.g. the OTel exporter handler frame attaches when telemetry is enabled) therefore forced records onto children whose level should have filtered them out.

Net effect in production: `LOG_LEVEL=info` had no visible effect — every frame service still wrote DEBUG records (full SQL queries, per-event acks) to stdout whenever telemetry was on.

## Fix

`Handle` now skips children whose `Enabled` rejects the record's level, and passes `r.Clone()` per the `slog.Handler` fan-out contract (handlers may retain/mutate the record).

## Testing

- New regression test `ChildLevelRespectedInFanOut`: an info-level standard handler plus a permissive debug-level extra handler; asserts debug records reach only the permissive child. Verified the test **fails** against the previous `Handle` implementation.
- Full `go test ./...` green.